### PR TITLE
Reset selected to false if initialRate is removed from props

### DIFF
--- a/src/Rating.jsx
+++ b/src/Rating.jsx
@@ -93,7 +93,8 @@ var Rating = React.createClass({
   componentWillReceiveProps: function (nextProps) {
       var rate = (nextProps.initialRate > 0) ? nextProps.initialRate : nextProps.placeholderRate;
       this.setState({
-        index: indexOf(nextProps, rate)
+        index: indexOf(nextProps, rate),
+        selected: !!nextProps.initialRate
       });
   },
   getInitialState: function () {


### PR DESCRIPTION
I'm not sure if this is in line with your expected behaviour, but in my application there are situations where I need to clear the selected rating and go back to the placeholder (ie. when the user logs out and their ratings are cleared). Currently if they had set any ratings while logged in, state.selected stays true even if props.initialRate is set to null, and the wrong colour is displayed. This pull request fixes that issue.