### PR TITLE
Include source in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "files": [
     "README.md",
     "LICENSE.md",
-    "lib/"
+    "lib/",
+    "src/"
   ],
   "scripts": {
     "test": "mocha --compilers js:babel/register --recursive",


### PR DESCRIPTION
Include the source for package distribution. This will allow other to rebuild / webpack when needed.

We need to do this;  because we do bundle the react and all components together. 