### PR TITLE
Reduce wasted renders

### DIFF
--- a/src/Rating.jsx
+++ b/src/Rating.jsx
@@ -32,7 +32,7 @@ class Rating extends React.Component {
       index: indexOf(props, index),
       indexOver: undefined,
       // Default direction is left to right
-      direction: 'ltr'
+      direction: window.getComputedStyle(document.body).getPropertyValue("direction")
     };
     this.handleClick = this.handleClick.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
@@ -40,10 +40,6 @@ class Rating extends React.Component {
   }
 
   componentDidMount() {
-    this.setState({
-      // detect the computed direction style for the mounted component
-      direction: window.getComputedStyle(this.refs.container, null).getPropertyValue("direction")
-    });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/Rating.jsx
+++ b/src/Rating.jsx
@@ -161,7 +161,7 @@ class Rating extends React.Component {
     }
 
     return (
-      <span ref="container" onMouseLeave={!readonly && this.handleMouseLeave} {...other}>
+      <span ref={(ref) => {this.container = ref;} } onMouseLeave={!readonly && this.handleMouseLeave} {...other}>
         {symbolNodes}
       </span>
     );


### PR DESCRIPTION
Moved the calculation of the direction to the constructor of the Rating
component.

Having a `setState` inside the `componentDidMount` is not a good thing
to do to begin with, because [it forces a
re-render](https://facebook.github.io/react/docs/react-component.html#componentdidmount).

Since it is not much likely that the text direction of the page will
change during use, I moved the calculation to the constructor.

Current implementation
![old](https://cloud.githubusercontent.com/assets/3789226/25148738/99d3b370-2484-11e7-8a53-a3c4bae860f8.PNG)

This PR
![new](https://cloud.githubusercontent.com/assets/3789226/25148737/99cef362-2484-11e7-9289-ad0d40826cee.PNG)

The screenshots are from a page of a project of mine, which has 20 instances of 5-star Rating components