### PR TITLE
updated react to 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     "mocha": "^2.2.5",
     "node-libs-browser": "^0.5.2",
     "prismjs": "^1.6.0",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "webpack": "^1.10.1",
     "webpack-dev-server": "^1.10.1"
   }

--- a/src/PercentageSymbol.jsx
+++ b/src/PercentageSymbol.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types'
 
 // Return the corresponding React node for an icon.
 const _iconNode = (icon) => {
@@ -52,17 +53,17 @@ const PercentageSymbol = (props) => {
 
 // Define propTypes only in development. They will be void in production.
 PercentageSymbol.propTypes = typeof __DEV__ !== 'undefined' && __DEV__ && {
-  icon: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-    React.PropTypes.element
+  icon: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.element
   ]),
-  background: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-    React.PropTypes.element
+  background: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.element
   ]),
-  percent: React.PropTypes.number
+  percent: PropTypes.number
 };
 
 module.exports = PercentageSymbol;

--- a/src/Rating.jsx
+++ b/src/Rating.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types'
 import Style from './style';
 import Symbol from './PercentageSymbol';
 
@@ -188,51 +189,51 @@ Rating.defaultProps = {
 
 // Define propTypes only in development.
 Rating.propTypes = typeof __DEV__ !== 'undefined' && __DEV__ && {
-  start: React.PropTypes.number,
-  stop: React.PropTypes.number,
-  step: React.PropTypes.number,
-  initialRate: React.PropTypes.number,
-  placeholderRate: React.PropTypes.number,
-  empty: React.PropTypes.oneOfType([
+  start: PropTypes.number,
+  stop: PropTypes.number,
+  step: PropTypes.number,
+  initialRate: PropTypes.number,
+  placeholderRate: PropTypes.number,
+  empty: PropTypes.oneOfType([
     // Array of class names and/or style objects.
-    React.PropTypes.arrayOf(React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-      React.PropTypes.element
+    PropTypes.arrayOf(PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+      PropTypes.element
     ])),
     // Class names.
-    React.PropTypes.string,
+    PropTypes.string,
     // Style objects.
-    React.PropTypes.object]),
-  placeholder: React.PropTypes.oneOfType([
+    PropTypes.object]),
+  placeholder: PropTypes.oneOfType([
     // Array of class names and/or style objects.
-    React.PropTypes.arrayOf(React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-      React.PropTypes.element
+    PropTypes.arrayOf(PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+      PropTypes.element
     ])),
     // Class names.
-    React.PropTypes.string,
+    PropTypes.string,
     // Style objects.
-    React.PropTypes.object]),
-  full: React.PropTypes.oneOfType([
+    PropTypes.object]),
+  full: PropTypes.oneOfType([
     // Array of class names and/or style objects.
-    React.PropTypes.arrayOf(React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
-      React.PropTypes.element
+    PropTypes.arrayOf(PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+      PropTypes.element
     ])),
     // Class names.
-    React.PropTypes.string,
+    PropTypes.string,
     // Style objects.
-    React.PropTypes.object]),
-  readonly: React.PropTypes.bool,
-  quiet: React.PropTypes.bool,
-  fractions: React.PropTypes.number,
-  scale: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  onClick: React.PropTypes.func,
-  onRate: React.PropTypes.func
+    PropTypes.object]),
+  readonly: PropTypes.bool,
+  quiet: PropTypes.bool,
+  fractions: PropTypes.number,
+  scale: PropTypes.number,
+  onChange: PropTypes.func,
+  onClick: PropTypes.func,
+  onRate: PropTypes.func
 };
 
 module.exports = Rating;


### PR DESCRIPTION
fixed PropType deprecation, it now uses it's own depencency prop-type

remade without changes on /lib folder

source: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html