### PR TITLE
Use updater version of setState when calculating based on current state.

### DIFF
--- a/src/Rating.jsx
+++ b/src/Rating.jsx
@@ -23,10 +23,10 @@ class Rating extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
     const valueChanged = this.props.value !== nextProps.value;
-    this.setState({
-      dirty: valueChanged || this.state.dirty,
-      displayValue: valueChanged ? nextProps.value : this.state.displayValue
-    });
+    this.setState((prevState) => ({
+      dirty: valueChanged || prevState.dirty,
+      displayValue: valueChanged ? nextProps.value : prevState.displayValue
+    }));
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
Fixes #80. When calling `setState` to update the state based on the _existing_ state, the updater function version of `setState` should be used, since calls to `setState` can potentially be batched.