### PR TITLE
fix(types): Adds classNames typing to RatingComponentProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ interface RatingComponentProps {
     step?: number;
     fractions?: number;
     initialRating?: number;
+    className?: string;
     placeholderRating?: number;
     readonly?: boolean;
     quiet?: boolean;


### PR DESCRIPTION
When using the component it would be nice to use the `className` prop without having to work around the TypeScript compiler