### PR TITLE
Export types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,9 @@ import * as React from "react";
 declare class Rating extends React.Component<RatingComponentProps> {}
 declare namespace Rating {}
 
-type RatingComponentSymbol = string | string[] | Dictionary<any> | Dictionary<any>[] | JSX.Element[] | JSX.Element ;
+export type RatingComponentSymbol = string | string[] | Dictionary<any> | Dictionary<any>[] | JSX.Element[] | JSX.Element ;
 
-interface RatingComponentProps {
+export interface RatingComponentProps {
     start?: number;
     stop?: number;
     step?: number;


### PR DESCRIPTION
This just exports the RatingComponentProps types so it can be imported elsewhere. 

In my case I needed these types to be exported so I could extend them in a custom rating wrapper component.