### PR TITLE
Fix deprecation warnings for componentWillReceiveProps

### DIFF
--- a/src/Rating.js
+++ b/src/Rating.js
@@ -17,7 +17,7 @@ class Rating extends React.PureComponent {
     this.symbolClick = this.symbolClick.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const valueChanged = this.props.value !== nextProps.value;
     this.setState((prevState) => ({
       displayValue: valueChanged ? nextProps.value : prevState.displayValue

--- a/src/RatingAPILayer.js
+++ b/src/RatingAPILayer.js
@@ -14,7 +14,7 @@ class RatingAPILayer extends React.PureComponent {
     this.handleHover = this.handleHover.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       value: nextProps.initialRating
     });


### PR DESCRIPTION
Fixes warning:

Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Rating, RatingAPILayer