### PR TITLE
Refactor willReceiveProps usages into getDerivedStateFromProps

### DIFF
--- a/src/Rating.js
+++ b/src/Rating.js
@@ -17,6 +17,13 @@ class Rating extends React.PureComponent {
     this.symbolClick = this.symbolClick.bind(this);
   }
 
+  static getDerivedStateFromProps(props, prevState) {
+    const { value } = props;
+    return (value === prevState.displayValue)
+      ? { displayValue: value }
+      : null;
+  }
+
   componentDidUpdate(prevProps, prevState) {
     // Apply state update due to value changed from props.
     // Usually originated through an onClick event.

--- a/src/Rating.js
+++ b/src/Rating.js
@@ -18,7 +18,7 @@ class Rating extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    // Ignore state update due to value changed from props.
+    // Apply state update due to value changed from props.
     // Usually originated through an onClick event.
     const currentValue = this.props.value;
     if (prevProps.value !== this.props.value) {

--- a/src/Rating.js
+++ b/src/Rating.js
@@ -25,11 +25,9 @@ class Rating extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    // Apply state update due to value changed from props.
+    // Ignore state update due to value changed from props.
     // Usually originated through an onClick event.
-    const currentValue = this.props.value;
     if (prevProps.value !== this.props.value) {
-      this.setState({ displayValue: currentValue })
       return;
     }
 

--- a/src/Rating.js
+++ b/src/Rating.js
@@ -17,17 +17,12 @@ class Rating extends React.PureComponent {
     this.symbolClick = this.symbolClick.bind(this);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const valueChanged = this.props.value !== nextProps.value;
-    this.setState((prevState) => ({
-      displayValue: valueChanged ? nextProps.value : prevState.displayValue
-    }));
-  }
-
   componentDidUpdate(prevProps, prevState) {
     // Ignore state update due to value changed from props.
     // Usually originated through an onClick event.
+    const currentValue = this.props.value;
     if (prevProps.value !== this.props.value) {
+      this.setState({ displayValue: currentValue })
       return;
     }
 

--- a/src/RatingAPILayer.js
+++ b/src/RatingAPILayer.js
@@ -15,7 +15,7 @@ class RatingAPILayer extends React.PureComponent {
   }
 
   static getDerivedStateFromProps(props, prevState) {
-    const { initialRating } = this.props;
+    const { initialRating } = props;
     return (initialRating !== prevState.value)
       ? { value: initialRating }
       : null;

--- a/src/RatingAPILayer.js
+++ b/src/RatingAPILayer.js
@@ -14,10 +14,11 @@ class RatingAPILayer extends React.PureComponent {
     this.handleHover = this.handleHover.bind(this);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState({
-      value: nextProps.initialRating
-    });
+  componentWillUpdate(prevProps) {
+    const { initialRating } = this.props;
+    if (this.props.initialRating !== prevProps.initialRating) {
+      this.setState({ value: initialRating });
+    }
   }
 
   handleClick(value, e) {

--- a/src/RatingAPILayer.js
+++ b/src/RatingAPILayer.js
@@ -14,9 +14,9 @@ class RatingAPILayer extends React.PureComponent {
     this.handleHover = this.handleHover.bind(this);
   }
 
-  componentWillUpdate(prevProps) {
+  componentDidUpdate(prevProps) {
     const { initialRating } = this.props;
-    if (this.props.initialRating !== prevProps.initialRating) {
+    if (initialRating !== prevProps.initialRating) {
       this.setState({ value: initialRating });
     }
   }

--- a/src/RatingAPILayer.js
+++ b/src/RatingAPILayer.js
@@ -14,11 +14,11 @@ class RatingAPILayer extends React.PureComponent {
     this.handleHover = this.handleHover.bind(this);
   }
 
-  componentDidUpdate(prevProps) {
+  static getDerivedStateFromProps(props, prevState) {
     const { initialRating } = this.props;
-    if (initialRating !== prevProps.initialRating) {
-      this.setState({ value: initialRating });
-    }
+    return (initialRating !== prevState.value)
+      ? { value: initialRating }
+      : null;
   }
 
   handleClick(value, e) {

--- a/test/Rating-test.js
+++ b/test/Rating-test.js
@@ -60,20 +60,20 @@ describe('Rating', function () {
     });
 
     it('should have all symbols readonly', function () {
-      rating.props.children.forEach(function (symbol, i) {
+      rating.props.children.forEach(function (symbol) {
         expect(symbol.props.readonly).to.be.false;
       });
     });
     it('should not have mouse move handler', function () {
       var noop = require('../src/utils/noop');
-      rating.props.children.forEach(function (symbol, i) {
+      rating.props.children.forEach(function (symbol) {
         expect(symbol.props.onMouseMove).to.equal(noop);
       });
     });
 
     it('should not have click handler', function () {
       var noop = require('../src/utils/noop');
-      rating.props.children.forEach(function (symbol, i) {
+      rating.props.children.forEach(function (symbol) {
         expect(symbol.props.onClick).to.equal(noop);
       });
     });


### PR DESCRIPTION
## Motivation
Pull #128 fixed the warnings around `willReceiveProps`, but it did so by essentially silencing them. Given that `willReceiveProps` is deprecated, it'd be better to move to a different approach. This puts that logic in `didUpdate`, which is a better place for it.

## Changes
* Move logic from `willReceiveProps` to `didUpdate`
* Remove some extraneous args from some test functions

## Testing
See that the hover, click and reset functionality in the "Reset Rating" example in `index.html` still work.

## Note
I had a couple of tests failing, but they were also failing on master. Not quite sure what was going on there.